### PR TITLE
TEST and SHELL DEPS should be ignored

### DIFF
--- a/src/hexer_deps.erl
+++ b/src/hexer_deps.erl
@@ -8,11 +8,41 @@
 
 -spec resolve(string()) -> [dep()].
 resolve(AppDir) ->
-  {ok, Makefile} = file:read_file(filename:join([AppDir, "Makefile"])),
-  Regex = "dep_(\\w+) *?= *?hex +([\\w\\d\\.]+)",
-  RegexOpts = [{capture, all_but_first, list}, global, multiline],
-  case re:run(Makefile, Regex, RegexOpts) of
-    {match, Deps} ->
-      [{list_to_atom(Name), Version} || [Name, Version] <- Deps];
-    nomatch -> []
+  HexerMk = filename:join([AppDir, "hexer.mk"]),
+  try
+    create_hexer_mk(HexerMk),
+    Output = os:cmd("cd " ++ AppDir ++ "; make -f hexer.mk list-deps"),
+    DepStrings =
+      [ string:tokens(DepLine, [$=])
+      || DepLine <- string:tokens(Output, [$|, $\n])],
+    [ {to_dep_atom(Dep), hex_version(Fetch)}
+    || [Dep, Fetch] <- DepStrings, is_hex_dep(Fetch)]
+  after
+    _ = file:delete(HexerMk)
   end.
+
+create_hexer_mk(HexerMk) ->
+  Contents =
+    "include Makefile\n"
+    "\n"
+    "THE_DEPS = "
+      "$(foreach dep,"
+        "$(filter-out $(IGNORE_DEPS),$(BUILD_DEPS) $(DEPS)),"
+        "$(dep) = $(dep_$(dep))\\|)\n"
+    "\n"
+    "list-deps:\n"
+    "\t@echo $(THE_DEPS)\n",
+  ok = file:write_file(HexerMk, Contents).
+
+is_hex_dep(Fetch) ->
+  case string:tokens(Fetch, [$\s, $\t]) of
+    ["hex" | _] -> true;
+    _ -> false
+  end.
+
+hex_version(Fetch) ->
+  ["hex", Version | _] = string:tokens(Fetch, [$\s, $\t]),
+  Version.
+
+to_dep_atom(Dep) ->
+  list_to_atom([Char || Char <- Dep, Char /= $\s]).

--- a/test/hexer_deps_SUITE.erl
+++ b/test/hexer_deps_SUITE.erl
@@ -1,0 +1,120 @@
+-module(hexer_deps_SUITE).
+
+-include_lib("inaka_mixer/include/mixer.hrl").
+-mixin([{ hexer_test_utils
+        , [ init_per_suite/1
+          , end_per_suite/1
+          ]
+        }
+       ]).
+
+-export([ all/0
+        ]).
+
+-export([ resolve_basic/1
+        , resolve_empty/1
+        , resolve_multiple_lines/1
+        ]).
+
+-spec all() -> [atom()].
+all() -> hexer_test_utils:all(?MODULE).
+
+-spec resolve_basic(hexer_test_utils:config()) -> {comment, string()}.
+resolve_basic(_Config) ->
+
+  ct:comment("Simple Makefile works"),
+  create_makefile(
+    "DEPS = dep1 dep2 dep3\n"
+    "\n"
+    "dep_dep1 = hex 0.1.2\n"
+    "dep_dep2 = git https://github.com/user/dep2 b00b1e5\n"
+    ),
+
+  [{dep1, "0.1.2"}] = hexer_deps:resolve("."),
+
+  ct:comment("Shell/Test Deps should be ignored"),
+  create_makefile(
+    "DEPS = dep1 dep2 dep3\n"
+    "TEST_DEPS = dep4 dep5\n"
+    "SHELL_DEPS = dep6 dep7\n"
+    "\n"
+    "dep_dep1 = hex 0.1.2\n"
+    "dep_dep2 = git https://github.com/user/dep2 b00b1e5\n"
+    "dep_dep4 = hex 3.4.5\n"
+    "dep_dep5 = git https://github.com/user/dep5 e666999a\n"
+    "dep_dep6 = hex 6.7.8\n"
+    ),
+
+  [{dep1, "0.1.2"}] = hexer_deps:resolve("."),
+
+  {comment, ""}.
+
+-spec resolve_empty(hexer_test_utils:config()) -> {comment, string()}.
+resolve_empty(_Config) ->
+
+  ct:comment("Empty Makefile should produce no deps"),
+  create_makefile(""),
+  [] = hexer_deps:resolve("."),
+
+  ct:comment("No hex deps produce no deps"),
+  create_makefile(
+    "DEPS = dep1 dep2 dep3\n"
+    "\n"
+    "dep_dep1 = cp /a/path\n"
+    "dep_dep2 = git https://github.com/user/dep2 b00b1e5\n"
+    ),
+
+  [] = hexer_deps:resolve("."),
+
+  ct:comment("Shell/Test Deps should be ignored"),
+  create_makefile(
+    "DEPS = dep1 dep2 dep3\n"
+    "TEST_DEPS = dep4 dep5\n"
+    "SHELL_DEPS = dep6 dep7\n"
+    "\n"
+    "dep_dep2 = git https://github.com/user/dep2 b00b1e5\n"
+    "dep_dep4 = hex 3.4.5\n"
+    "dep_dep5 = git https://github.com/user/dep5 e666999a\n"
+    "dep_dep6 = hex 6.7.8\n"
+    ),
+
+  [] = hexer_deps:resolve("."),
+
+  {comment, ""}.
+
+-spec resolve_multiple_lines(hexer_test_utils:config()) -> {comment, string()}.
+resolve_multiple_lines(_Config) ->
+
+  ct:comment("Simple Makefile works"),
+  create_makefile(
+    "DEPS = dep1 dep2\n"
+    "DEPS += dep3\n"
+    "\n"
+    "dep_dep1 = hex 0.1.2\n"
+    "dep_dep2 = git https://github.com/user/dep2 b00b1e5\n"
+    "dep_dep3 = hex 3.4.5\n"
+    ),
+
+  [{dep1, "0.1.2"}, {dep3, "3.4.5"}] = hexer_deps:resolve("."),
+
+  ct:comment("Shell/Test Deps should be ignored"),
+  create_makefile(
+    "DEPS = dep1 dep2\n"
+    "TEST_DEPS = dep4 dep5\n"
+    "DEPS += dep3\n"
+    "SHELL_DEPS = dep6 dep7\n"
+    "\n"
+    "dep_dep1 = hex 6.7.8\n"
+    "dep_dep2 = git https://github.com/user/dep2 b00b1e5\n"
+    "dep_dep3 = hex 9.0.1\n"
+    "dep_dep4 = hex 2.3.4\n"
+    "dep_dep5 = git https://github.com/user/dep5 e666999a\n"
+    "dep_dep6 = hex 5.6.7\n"
+    ),
+
+  [{dep1, "6.7.8"}, {dep3, "9.0.1"}] = hexer_deps:resolve("."),
+
+  {comment, ""}.
+
+create_makefile(Contents) ->
+  ok = file:write_file("Makefile", ["include ../../erlang.mk\n", Contents]).


### PR DESCRIPTION
Only deps listed in `DEPS` should be considered as valid deps by `hexer_deps`

(issue found by @tsloughter)
