### PR TITLE
Don't filter an empty requirements list

### DIFF
--- a/src/hexer_package.erl
+++ b/src/hexer_package.erl
@@ -68,7 +68,11 @@ publish(AppDir, Name, Version, Deps, Details) ->
               , links        => Links
               , build_tools  => BuildTools
               },
-  EmptyValue = fun(_, "") -> false; (_, _) -> true end,
+  EmptyValue = fun
+                 (requirements, []) -> true;
+                 (_, "") -> false;
+                 (_, _) -> true
+               end,
   OptionalFiltered = maps:filter(EmptyValue, Optional),
   Mandatory = #{name => PackageName, version => Version},
   Meta = maps:merge(Mandatory, OptionalFiltered),


### PR DESCRIPTION
The option is mandatory, therefore hex.pm will reject the package if the
option is not given.
